### PR TITLE
feat: Geliştirici modunu arayüzde görünür yap

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@
         </header>
 
         <!-- Geliştirici Modu -->
-        <div class="hidden mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+        <div class="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
             <label class="flex items-center">
                 <input type="checkbox" id="devMode" class="mr-2">
                 <span class="text-yellow-800 font-semibold">🔧 Geliştirici Modu (2 dakika testi)</span>


### PR DESCRIPTION
`templates/index.html` dosyasındaki Geliştirici Modu bölümünü çevreleyen `div` etiketinden `hidden` CSS sınıfını kaldırdım. Bu değişiklik, test amacıyla 2 dakikalık bildirim zamanlayıcısını etkinleştirmenize olanak tanır.

## Sourcery Özeti

2 dakikalık bildirim zamanlayıcısının test edilmesine olanak sağlamak için ana şablondaki geliştirici modu bölümünü göster.

Yeni Özellikler:
- hidden CSS sınıfını kaldırarak kullanıcı arayüzünde geliştirici modu geçiş düğmesini erişime açın.
- Geliştirici modu aracılığıyla test için 2 dakikalık bir bildirim zamanlayıcısı etkinleştirin.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reveal the developer mode section in the main template to allow testing of the 2-minute notification timer.

New Features:
- Expose the developer mode toggle in the UI by removing the hidden CSS class
- Enable a 2-minute notification timer for testing through developer mode

</details>