### PR TITLE
Değişiklik: `apscheduler` tetikleyicisini 'date' olarak değiştirdim

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import requests
 from apscheduler.schedulers.background import BackgroundScheduler
 import logging
 import os
+from datetime import datetime, timedelta
 
 # Set up basic logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -60,17 +61,18 @@ def notify():
             job.remove()
             logging.info("Mevcut bildirim görevi iptal edildi.")
 
-    # Yeni bildirim görevini zamanla
+    # Yeni bildirim görevini 'date' tetikleyicisi ile zamanla
+    run_date = datetime.now() + timedelta(minutes=delay_minutes)
     scheduler.add_job(
         send_notification,
-        'interval',
-        minutes=delay_minutes,
+        trigger='date',
+        run_date=run_date,
         id='timed_notification',
         name='send_notification',
         replace_existing=True
     )
 
-    logging.info(f"Bildirim {delay_minutes} dakika sonrasına zamanlandı.")
+    logging.info(f"Bildirim, çalışmak üzere {run_date.strftime('%Y-%m-%d %H:%M:%S')} tarihine zamanlandı.")
     return {"status": "success", "message": f"Notification scheduled in {delay_minutes} minutes."}, 200
 
 def keep_alive():


### PR DESCRIPTION
Gunicorn worker'ları ile uyumluluğu artırmak ve zamanlanmış görevin kaybolmasını önlemek amacıyla, `apscheduler`'ın tetikleyici metodunu 'interval' yerine 'date' olarak güncelledim.

Artık görev, periyodik bir aralıkta değil, hesaplanan belirli bir tarih ve saatte tek seferlik çalışacak şekilde zamanlanıyor. Bu, arka plan görevinin daha güvenilir bir şekilde tetiklenmesini sağlamalıdır.

## Sourcery Özeti

Gunicorn çalışanlarıyla güvenilirliği artırmak için, bildirim görevlerini bir aralık yerine tek seferlik çalıştırma için bir tarih tetikleyicisi kullanarak zamanlayın.

Geliştirmeler:
- APScheduler tetikleyicisini, hesaplanan bir `run_date` ile 'interval'dan 'date'e geçirin.
- Her bildirim işi için `run_date` değerini hesaplayın ve iletin.
- Bildirimin tam olarak zamanlandığı tarih ve saati raporlamak için loglamayı güncelleyin.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Schedule notification tasks using a date trigger for a one-time run instead of an interval to improve reliability with Gunicorn workers.

Enhancements:
- Switch APScheduler trigger from 'interval' to 'date' with a computed run_date
- Compute and pass run_date for each notification job
- Update logging to report the exact date and time the notification is scheduled

</details>