### PR TITLE
fix: `requirements.txt` dosyasındaki VAPID paket adını düzelttim

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask>=2.0
 gunicorn>=20.0
 apscheduler>=3.6
 pywebpush>=1.13.0
-py-vapid>=1.9.0
+vapid>=1.0.1


### PR DESCRIPTION
`ModuleNotFoundError: No module named 'vapid'` hatasını çözmek için, `requirements.txt` dosyasındaki `py-vapid` girdisini, doğru PyPI paket adı olan `vapid` ile değiştirdim. Bu, Render'ın deploy sırasında doğru kütüphaneyi kurmasını ve uygulamanın başarıyla başlamasını sağlayacaktır.