### PR TITLE
fix: VAPID kütüphanesi için import ifadesini ve paket adını düzelt

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, request, jsonify, send_from_directory
 from apscheduler.schedulers.background import BackgroundScheduler
 from pywebpush import webpush, WebPushException
-from vapid import Vapid
+from py_vapid import Vapid
 import logging
 import os
 import json

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask>=2.0
 gunicorn>=20.0
 apscheduler>=3.6
 pywebpush>=1.13.0
-vapid>=1.0.1
+py-vapid>=1.9.0


### PR DESCRIPTION
`ModuleNotFoundError` hatasını çözmek için, `app.py` dosyasındaki import ifadesi `from py_vapid import Vapid` olarak düzeltildi. Ayrıca `requirements.txt` dosyasının doğru paket olan `py-vapid`'i içerdiği tekrar teyit edildi.

Bu değişiklik, uygulamanın VAPID anahtarlarını doğru bir şekilde oluşturmasını ve import hatası olmadan çalışmasını sağlayacaktır.