### PR TITLE
fix: VAPID public key için JavaScript kapsam sorununu düzelt

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,10 +5,6 @@
     <title>Ecrin'in Uyku Takibi</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <script>
-        // Bu değişken Flask tarafından render edilecektir.
-        const VAPID_PUBLIC_KEY = "{{ vapid_public_key }}";
-    </script>
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
     <div class="container mx-auto px-4 py-8 max-w-4xl">
@@ -71,6 +67,9 @@
     </div>
 
     <script>
+        // Bu değişken Flask tarafından render edilecektir ve tüm script'in başında olmalıdır.
+        const VAPID_PUBLIC_KEY = "{{ vapid_public_key }}";
+
         const DEV_MODE_KEY = 'ecrin_dev_mode';
         const devModeCheckbox = document.getElementById('devMode');
         const permissionDiv = document.getElementById('permissionDiv');


### PR DESCRIPTION
`VAPID_PUBLIC_KEY` değişkeninin JavaScript tarafından tanınmaması sorununu çözmek için, değişken tanımı ana `<script>` bloğunun içine taşındı. Ayrı bir `<script>` etiketi kullanmak, tarayıcının kodları farklı zamanlarda işlemesine ve kapsam sorunlarına yol açabiliyordu.

Bu değişiklik, `VAPID_PUBLIC_KEY is not defined` hatasını giderir.