### PR TITLE
fix: Yanıtlara `Permissions-Policy` başlığı ekle

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,6 +54,12 @@ def send_push_notification(subscription_info, message_body):
             push_subscription = None
 
 # -- Route'lar (Endpoints) --
+@app.after_request
+def add_security_headers(response):
+    """Tarayıcı kısıtlamalarını önlemek için gerekli güvenlik başlıklarını ekle."""
+    response.headers['Permissions-Policy'] = 'notifications=*'
+    return response
+
 @app.route('/')
 def index():
     return render_template('index.html', vapid_public_key=VAPID_PUBLIC_KEY)


### PR DESCRIPTION
Tarayıcıların, özellikle iframe içinde çalışan uygulamalarda, bildirim izni istemesini engelleyebilen kısıtlamaları aşmak için sunucudan giden tüm yanıtlara `Permissions-Policy: notifications=*` HTTP başlığı ekledim.

Bu değişiklik, platform kaynaklı olası izin engellemelerini ortadan kaldırarak `Notification.requestPermission()`'ın başarıyla tetiklenmesini sağlamayı amaçlar.